### PR TITLE
Add organisation config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ octopusenergy:
 
 influxdb:
   url: "http://localhost:8086"
+  # org: "Utilities"
   database: "octopusenergy"
   token: ""
   
@@ -24,6 +25,8 @@ gas:
   serial: "..."
 ```
 *Note: InfluxDB authorization token is optional.*
+
+*Note: Organization is required for InfluxDB v2.*
 
 If you don't wish to get electricity or gas data, just remove that part of configuration file.
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -3,6 +3,7 @@ octopusenergy:
 
 influxdb:
   url: "http://localhost:8086"
+  # org: ""
   database: "octopusenergy"
   token: ""
   

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ type Config struct {
 	} `yaml:"octopusenergy"`
 	Influx struct {
 		URL      string `yaml:"url"`
+		Org      string `yaml:"org"`
 		Database string `yaml:"database"`
 		Token    string `yaml:"token"`
 	} `yaml:"influxdb"`
@@ -75,7 +76,7 @@ func getLastTime(cfg *Config, iClient influxdb2.Client, fuel string) (time.Time,
 		return time.Time{}, errors.New("incorrect fuel type")
 	}
 
-	queryAPI := iClient.QueryAPI("")
+	queryAPI := iClient.QueryAPI(cfg.Influx.Org)
 
 	// Get latest electricity entry
 	res, err := queryAPI.Query(context.Background(), `from(bucket:"`+cfg.Influx.Database+`")
@@ -122,7 +123,7 @@ func main() {
 
 	// InfluxDB
 	iClient := influxdb2.NewClient(cfg.Influx.URL, cfg.Influx.Token)
-	writeAPI := iClient.WriteAPI("", cfg.Influx.Database)
+	writeAPI := iClient.WriteAPI(cfg.Influx.Org, cfg.Influx.Database)
 
 	// Set up Octopus client
 	client, err := octopusenergyapi.NewClient(cfg.Octopus.Token, http.DefaultClient)


### PR DESCRIPTION
Required for InfluxDB v2.

Providing no option defaults to the empty string, preserving default behaviour for old config files.