### PR TITLE
Fix gas unit for SMETS1 meters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,16 @@ electricity:
 gas:
   mpan: "...."
   serial: "..."
+  # type: smets1
 ```
 *Note: InfluxDB authorization token is optional.*
 
 *Note: Organization is required for InfluxDB v2.*
 
 If you don't wish to get electricity or gas data, just remove that part of configuration file.
+
+`type: smets1` must be specified for SMETS1 meters to ensure correct unit for gas meter readings.
+This can be omitted for SMETS2 meters.
 
 Tested with InfluxDB v1.8.3 - compatibility with InfluxDB 2.0 not guaranteed.
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -14,3 +14,4 @@ electricity:
 gas:
   mpan: ""
   serial: ""
+  # type: smets1


### PR DESCRIPTION
SMETS1 meters report gas consumption in kWh, see https://developer.octopus.energy/docs/api/#consumption

This commit adds an option to set the gas meter type should a SMETS1 meter be in use and the readings be in kWh.
The default behaviour still assumes SMETS2 and assumes the readings to be in m3.

I tried to avoid having to add another config option for this, but could not find a way to reliably determine the meter type.